### PR TITLE
Update CouponSubTcc.php

### DIFF
--- a/src/Example/Tcc/CouponSubTcc.php
+++ b/src/Example/Tcc/CouponSubTcc.php
@@ -15,7 +15,7 @@ class CouponSubTcc extends TccOption
     {
 
         # 获取优惠券ID, 依赖 CouponLockTcc::class 操作返回
-        $this->couponId = (int)$this->tcc->get(CouponLockTcc::class, 0);
+        $this->couponId = (int)($this->tcc->get(CouponLockTcc::class, [])['id'] ?? 0);
         if ($this->couponId) {
 
             # 占用优惠券


### PR DESCRIPTION
修复占用优惠券时获取优惠券ID，CouponLockTcc返回为数组，转为int时永远为1